### PR TITLE
chore: use hoisted node_modules

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted


### PR DESCRIPTION
In stackblitz, typescript seems to not like the symlinked architecture of node_modules. For instance, react-query is not correctly types. Hoisted is the same folder structure as npm
